### PR TITLE
Browser passive touch* event fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1829,27 +1829,31 @@ const webGLFluidEnhanced = {
       updatePointerUpData(pointers[0]);
     });
 
-    canvas.addEventListener('touchstart', (e) => {
-      e.preventDefault();
-      const touches = e.targetTouches;
-      while (touches.length >= pointers.length)
-        pointers.push(new pointerPrototype());
-      for (let i = 0; i < touches.length; i++) {
-        let posX = scaleByPixelRatio(touches[i].pageX);
-        let posY = scaleByPixelRatio(touches[i].pageY);
-        updatePointerDownData(
-          pointers[i + 1],
-          touches[i].identifier,
-          posX,
-          posY,
-        );
-      }
-    });
+    canvas.addEventListener(
+      'touchstart',
+      (e) => {
+        // e.preventDefault();
+        const touches = e.targetTouches;
+        while (touches.length >= pointers.length)
+          pointers.push(new pointerPrototype());
+        for (let i = 0; i < touches.length; i++) {
+          let posX = scaleByPixelRatio(touches[i].pageX);
+          let posY = scaleByPixelRatio(touches[i].pageY);
+          updatePointerDownData(
+            pointers[i + 1],
+            touches[i].identifier,
+            posX,
+            posY,
+          );
+        }
+      },
+      { passive: false, capture: true },
+    );
 
     canvas.addEventListener(
       'touchmove',
       (e) => {
-        e.preventDefault();
+        // e.preventDefault();
         const touches = e.targetTouches;
         for (let i = 0; i < touches.length; i++) {
           let pointer = pointers[i + 1];
@@ -1858,7 +1862,7 @@ const webGLFluidEnhanced = {
           updatePointerMoveData(pointer, posX, posY);
         }
       },
-      false,
+      { passive: false, capture: true },
     );
 
     window.addEventListener('touchend', (e) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1832,7 +1832,6 @@ const webGLFluidEnhanced = {
     canvas.addEventListener(
       'touchstart',
       (e) => {
-        // e.preventDefault();
         const touches = e.targetTouches;
         while (touches.length >= pointers.length)
           pointers.push(new pointerPrototype());
@@ -1853,7 +1852,6 @@ const webGLFluidEnhanced = {
     canvas.addEventListener(
       'touchmove',
       (e) => {
-        // e.preventDefault();
         const touches = e.targetTouches;
         for (let i = 0; i < touches.length; i++) {
           let pointer = pointers[i + 1];


### PR DESCRIPTION
This change removes: 
`[Violation] Added non-passive event listener to a scroll-blocking...  `
warning from the console. 